### PR TITLE
use last node instead of prev and pass shellcheck

### DIFF
--- a/alternative/bspswallow
+++ b/alternative/bspswallow
@@ -3,25 +3,24 @@
 # Get class of a wid
 get_class() {
 	id=$1
-  if [ -z $id ]; then
+  if [ -z "$id" ]; then
     echo ""
   else
-	  xprop -id $id | sed -n '/WM_CLASS\|WM_COMMAND/s/.*"\(.*\)".*/\1/p'
+	  xprop -id "$id" | sed -n '/WM_CLASS\|WM_COMMAND/s/.*"\(.*\)".*/\1/p'
   fi
 }
 
 swallow() {
 	addedtodesktop=$2
-	echo $addedtodesktop
-	lasttermdesktop=$(bspc query -D -n prev)
-	echo $lasttermdesktop
+	lasttermdesktop=$(bspc query -D -n last)
+
 	swallowerid=$1
-	swallowingid=$(bspc query -n prev -N)
-	if [ $addedtodesktop = $lasttermdesktop ]; then
-		grep "^$(get_class $swallowerid)$" ~/.config/bspwm/swallow || return
-		grep "^$(get_class $swallowingid)$" ~/.config/bspwm/terminals || return
-		echo $swallowerid $swallowingid >> /tmp/swallowids
-		bspc node $swallowingid --flag hidden=on
+	swallowingid=$(bspc query -N -n last)
+	if [ "$addedtodesktop" = "$lasttermdesktop" ]; then
+		grep "^$(get_class "$swallowerid")$" ~/.config/bspwm/swallow || return
+		grep "^$(get_class "$swallowingid")$" ~/.config/bspwm/terminals || return
+		echo "$swallowerid $swallowingid" >> /tmp/swallowids
+		bspc node "$swallowingid" --flag hidden=on
 	fi
 }
 
@@ -29,20 +28,20 @@ spit() {
 	spitterid=$1
 	grep "^$spitterid" /tmp/swallowids || return
 	spittingid=$(grep "^$spitterid" /tmp/swallowids | head -n1 | awk '{print $2}')
-	bspc node $spittingid --flag hidden=off
-	bspc node $spittingid -f
+	bspc node "$spittingid" --flag hidden=off
+	bspc node "$spittingid" -f
 	sed -i "/^$spitterid/d" /tmp/swallowids
 }
 
 bspc subscribe node_add node_remove | while read -r event
 do
-	
-	case "$(echo $event | awk '{ print $1 }')" in
+	case "$(echo "$event" | awk '{ print $1 }')" in
 		node_add)
-			swallow $(echo $event | awk '{print $5 " " $3}')
+			read -r node desktop < "$(echo "$event" | awk '{print $5 " " $3}')"
+            swallow "$node" "$desktop"
 			;;
 		node_remove)
-			spit $(echo $event | awk '{print $4}')
+			spit "$(echo "$event" | awk '{print $4}')"
 			;;
 	esac
 done

--- a/alternative/bspswallow
+++ b/alternative/bspswallow
@@ -37,8 +37,8 @@ bspc subscribe node_add node_remove | while read -r event
 do
 	case "$(echo "$event" | awk '{ print $1 }')" in
 		node_add)
-			read -r node desktop < "$(echo "$event" | awk '{print $5 " " $3}')"
-            swallow "$node" "$desktop"
+            # shellcheck disable=SC2046
+			swallow $(echo "$event" | awk '{print $5 " " $3}')
 			;;
 		node_remove)
 			spit "$(echo "$event" | awk '{print $4}')"

--- a/bspswallow
+++ b/bspswallow
@@ -38,8 +38,8 @@ bspc subscribe node_add node_remove | while read -r event
 do
 	case $(echo "$event" | awk '{ print $1 }') in
 		node_add)
-            read -r node desktop < "$(echo "$event" | awk '{print $5 " " $3}')"
-            swallow "$node" "$desktop"
+            # shellcheck disable=SC2046
+            swallow $(echo "$event" | awk '{print $5 " " $3}')
 			;;
 		node_remove)
 			spit "$(echo "$event" | awk '{print $4}')"

--- a/bspswallow
+++ b/bspswallow
@@ -3,25 +3,25 @@
 # Get class of a wid
 get_class() {
 	id=$1
-  if [ -z $id ]; then
+  if [ -z "$id" ]; then
     echo ""
   else
-	  xprop -id $id | sed -n '/WM_CLASS\|WM_COMMAND/s/.*"\(.*\)".*/\1/p'
+	  xprop -id "$id" | sed -n '/WM_CLASS\|WM_COMMAND/s/.*"\(.*\)".*/\1/p'
   fi
 }
 
 swallow() {
 	addedtodesktop=$2
-	echo $addedtodesktop
-	lasttermdesktop=$(bspc query -D -n prev)
-	echo $lasttermdesktop
+	lasttermdesktop=$(bspc query -D -n last)
+
 	swallowerid=$1
-	swallowingid=$(bspc query -n prev -N)
-	if [ $addedtodesktop = $lasttermdesktop ]; then
-		cat ~/.config/bspwm/noswallow ~/.config/bspwm/terminals | grep "^$(get_class $swallowerid)$" && return
-		grep "^$(get_class $swallowingid)$" ~/.config/bspwm/terminals || return
-		echo $swallowerid $swallowingid >> /tmp/swallowids
-		bspc node $swallowingid --flag hidden=on
+	swallowingid=$(bspc query -N -n last)
+
+	if [ "$addedtodesktop" = "$lasttermdesktop" ]; then
+		cat ~/.config/bspwm/noswallow ~/.config/bspwm/terminals | grep "^$(get_class "$swallowerid")$" && return
+		grep "^$(get_class "$swallowingid")$" ~/.config/bspwm/terminals || return
+		echo "$swallowerid $swallowingid" >> /tmp/swallowids
+		bspc node "$swallowingid" --flag hidden=on
 	fi
 }
 
@@ -29,20 +29,20 @@ spit() {
 	spitterid=$1
 	grep "^$spitterid" /tmp/swallowids || return
 	spittingid=$(grep "^$spitterid" /tmp/swallowids | head -n1 | awk '{print $2}')
-	bspc node $spittingid --flag hidden=off
-	bspc node $spittingid -f
+	bspc node "$spittingid" --flag hidden=off
+	bspc node "$spittingid" -f
 	sed -i "/^$spitterid/d" /tmp/swallowids
 }
 
 bspc subscribe node_add node_remove | while read -r event
 do
-	
-	case "$(echo $event | awk '{ print $1 }')" in
+	case $(echo "$event" | awk '{ print $1 }') in
 		node_add)
-			swallow $(echo $event | awk '{print $5 " " $3}')
+            read -r node desktop < "$(echo "$event" | awk '{print $5 " " $3}')"
+            swallow "$node" "$desktop"
 			;;
 		node_remove)
-			spit $(echo $event | awk '{print $4}')
+			spit "$(echo "$event" | awk '{print $4}')"
 			;;
 	esac
 done


### PR DESCRIPTION
Nice project! It didn't work for me, the `bspc query` always got the wrong window, it only worked when I queried for `last` instead of `prev`. I also thought I'd fix the shellcheck warnings. Test if this also works for you too before merging, if you would like to. Cheers! 