### PR TITLE
Use pgrep instead of grepping ps output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If a class isn't available (such as with xev) then the command of origin can be 
 Place bspswallow into your PATH and add the following line to your bspwmrc.
 
 ```
-(ps x | grep bspswallow | grep -v grep) || bspswallow &
+pgrep bspswallow || bspswallow &
 ```
 
 Now just restart bspwm and you're good to go.


### PR DESCRIPTION
Shellcheck reports the following:

```
(ps x | grep bspswallow | grep -v grep) || bspswallow
 ^-- SC2009: Consider using pgrep instead of grepping ps output.
```

Using pgrep works as expected and seems much simpler.